### PR TITLE
`@Identifiable` macro and other cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,12 +159,12 @@ to be sure that the backend folks are always sending you v4 UUIDs in there since
 supports. You'll probably also need to do something about those hex colors but that's just because this is a terribly
 contrived example.
 
-Then again, what would you need to do to _encode_ your UUID-based strongly typed IDs into something that the backend can
-chew on? _absolutely nothing_. Usually, that is. As a gesture of friendship to long-suffering backend developers a
-`UUID`-backed strongly typed ID will encode in lowercase, since that's almost always what the backend expects. Other
-than that they'll just encode themselves into the string form of the UUID and off you go. If additional work is required
-to translate into peculiar backend expectations, you can always add a custom `Encodable` implementation to your
-identifier type.
+Then again, what would you need to do to _encode_ your UUID-based identifier into something that the backend can chew
+on? _absolutely nothing_. Usually, that is. As a gesture of friendship to long-suffering backend developers a
+`UUID`-backed identifier will encode in lowercase, since that's almost always what the backend expects. Other than that
+they'll just encode themselves into the string form of the UUID and off you go. If additional work is required to
+translate into peculiar backend expectations, you can always add a custom `Encodable` implementation to your identifier
+type.
 
 ## Testability
 

--- a/Sources/Identity/Identifier+Comparable.swift
+++ b/Sources/Identity/Identifier+Comparable.swift
@@ -1,0 +1,22 @@
+//
+//  Identifier+Comparable.swift
+//  swift-identity
+//
+//  Created by Óscar Morales Vivó on 6/21/25.
+//
+
+import Foundation
+
+public extension Identifier where Self: Comparable, RawValue: Comparable {
+    /// Default `Comparable` conformance.
+    ///
+    /// Most of the time IDs should not be treated as comparable as they specify uniqueness, not sort order. But if
+    /// convenient or required this default implementation will take care of the matter. You still need to declare it
+    /// on your specific ID type as `MyIDType: Comparable`.
+    ///
+    /// Swift warnings may happen if you do that outside of the module where you declare a given identifier type, i.e.
+    /// its associated testing target. They should be safe to ignore as long as you control the type.
+    static func < (lhs: Self, rhs: Self) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+}

--- a/Sources/Identity/Identifier+Macros.swift
+++ b/Sources/Identity/Identifier+Macros.swift
@@ -33,3 +33,17 @@ public macro Identifier<Backing: Hashable & Codable & Sendable>() = #externalMac
     module: "IdentityMacros",
     type: "AttachedIdentifierMacro"
 )
+
+/// A macro that adds conformance to `Identifiable` with a new `Identifier` type to its attachee.
+///
+/// The macro will declare an `ID` type conforming to ``Identifier`` and backed by the type used to call the macro, as
+/// well as the corresponding `id` property.
+///
+/// This simplifies the typical case of an embedded ID type for a model type.
+/// - Parameter Backing: The type that backs the ``Identifier`` type, its `RawValue`.
+@attached(member, names: named(ID), named(id))
+@attached(extension, conformances: Identifiable)
+public macro Identifiable<Backing: Hashable & Codable & Sendable>() = #externalMacro(
+    module: "IdentityMacros",
+    type: "AttachedIdentifiableMacro"
+)

--- a/Sources/Identity/Identifier+Testing.swift
+++ b/Sources/Identity/Identifier+Testing.swift
@@ -46,7 +46,7 @@ public extension Identifier where Self: ExpressibleByIntegerLiteral, RawValue: E
 }
 
 /**
- We want to avoid accidental conversion from literals to strongly typed IDs, but this default implementation allows us
+ We want to avoid accidental conversion from literals to ``Identifier`` types, but this default implementation allows us
  to declare `ExpressibleByFloatLiteral` conformance and have it automagically implemented. Useful for testing purposes
  where you may want to create dummy IDs with a known value.
 

--- a/Sources/Identity/Identifier+UUID.swift
+++ b/Sources/Identity/Identifier+UUID.swift
@@ -8,12 +8,12 @@
 import Foundation
 
 public extension Identifier where RawValue == UUID {
-    /// Simple factory method for `UUID`-based strongly typed IDs.
+    /// Simple factory method for `UUID`-based identifiers.
     ///
     /// For UUID-based ``Identifier`` types we either copy them around or generate unique ones on demand. This method
     /// takes care of the latter without having to actually deal with `UUID` itself. The explicit generation is also
     /// more readable.
-    /// - Returns: A new unique value of the `UUID`-based strongly typed ID.
+    /// - Returns: A new unique value of the `UUID`-based identifier.
     static func unique() -> Self {
         .init(rawValue: UUID())!
     }

--- a/Sources/Identity/Identifier.swift
+++ b/Sources/Identity/Identifier.swift
@@ -25,25 +25,9 @@ public protocol Identifier: RawRepresentable, Codable, CustomStringConvertible, 
 public extension Identifier {
     /// Default `CustomStringConvertible` conformance.
     ///
-    /// Strongly typed IDs use only their raw values for their conversion to strings. This makes them easy to use as
-    /// values passed to logging and reporting methods.
+    /// Identifier conforming types use only their raw values for their conversion to strings. This makes them easy to
+    /// use as values passed to logging and reporting methods.
     var description: String {
         String(describing: rawValue)
-    }
-}
-
-// MARK: - Default `Comparable` Conformance
-
-public extension Identifier where Self: Comparable, RawValue: Comparable {
-    /// Default `Equatable` conformance.
-    ///
-    /// Most of the time IDs should not be treated as comparable as they specify uniqueness, not sort order. But if
-    /// convenient or required this default implementation will take care of the matter. You still need to declare it
-    /// on your specific ID type as `MyIDType: Comparable`.
-    ///
-    /// Swift warnings may happen if you do that outside of the module where you declare a given identifier type, i.e.
-    /// its associated testing target. They should be safe to ignore as long as you control the type.
-    static func < (lhs: Self, rhs: Self) -> Bool {
-        lhs.rawValue < rhs.rawValue
     }
 }

--- a/Sources/IdentityMacros/AttachedIdentifiableMacro.swift
+++ b/Sources/IdentityMacros/AttachedIdentifiableMacro.swift
@@ -1,18 +1,18 @@
 //
-//  AttachedIdentifierMacro.swift
-//  Identifier
+//  AttachedIdentifiableMacro.swift
+//  swift-identity
 //
-//  Created by Óscar Morales Vivó on 6/8/25.
+//  Created by Óscar Morales Vivó on 6/21/25.
 //
 
 import SwiftSyntax
 import SwiftSyntaxMacros
 
-public struct AttachedIdentifierMacro {}
+public struct AttachedIdentifiableMacro {}
 
 // MARK: - MemberMacro Conformance
 
-extension AttachedIdentifierMacro: MemberMacro {
+extension AttachedIdentifiableMacro: MemberMacro {
     public static func expansion(
         of _: AttributeSyntax,
         providingMembersOf declaration: some DeclGroupSyntax,
@@ -32,16 +32,21 @@ extension AttachedIdentifierMacro: MemberMacro {
         let access = declaration.modifiers.first(where: \.isNeededAccessLevelModifier)
 
         return [
-            "\(access)init(rawValue: \(genericParam)) { self.rawValue = rawValue }",
-            "\(access)typealias RawValue = \(genericParam)",
-            "\(access)var rawValue: \(genericParam)"
+            """
+            \(access)struct ID: Identifier {
+                init(rawValue: \(genericParam)) { self.rawValue = rawValue }
+
+                var rawValue: \(genericParam)
+            }
+            """,
+            "\(access)var id: ID"
         ]
     }
 }
 
 // MARK: - ExtensionMacro Conformance
 
-extension AttachedIdentifierMacro: ExtensionMacro {
+extension AttachedIdentifiableMacro: ExtensionMacro {
     public static func expansion(
         of _: AttributeSyntax,
         attachedTo _: some DeclGroupSyntax,
@@ -50,8 +55,8 @@ extension AttachedIdentifierMacro: ExtensionMacro {
         in _: some MacroExpansionContext
     ) throws -> [ExtensionDeclSyntax] {
         // This is all simple enough.
-        let identifierConformance = try ExtensionDeclSyntax("extension \(type.trimmed): Identifier {}")
+        let identifiableConformance = try ExtensionDeclSyntax("extension \(type.trimmed): Identifiable {}")
 
-        return [identifierConformance]
+        return [identifiableConformance]
     }
 }

--- a/Sources/IdentityMacros/IdentityMacrosTestPlugin.swift
+++ b/Sources/IdentityMacros/IdentityMacrosTestPlugin.swift
@@ -6,12 +6,23 @@
 //
 
 import SwiftCompilerPlugin
+import SwiftSyntax
 import SwiftSyntaxMacros
 
 @main
 struct IdentityMacrosTestPlugin: CompilerPlugin {
     let providingMacros: [Macro.Type] = [
-        FreestandingIdentifierMacro.self,
-        AttachedIdentifierMacro.self
+        AttachedIdentifiableMacro.self,
+        AttachedIdentifierMacro.self,
+        FreestandingIdentifierMacro.self
     ]
+}
+
+extension DeclModifierSyntax {
+    var isNeededAccessLevelModifier: Bool {
+        switch name.tokenKind {
+        case .keyword(.public): true
+        default: false
+        }
+    }
 }

--- a/Tests/IdentityTests/AttachedIdentifiableMacroTests.swift
+++ b/Tests/IdentityTests/AttachedIdentifiableMacroTests.swift
@@ -1,0 +1,100 @@
+//
+//  AttachedIdentifiableMacroTests.swift
+//
+//
+//  Created by Óscar Morales Vivó on 9/21/23.
+//
+
+import Foundation
+import Identity
+import SwiftDiagnostics
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import XCTest
+
+// Macro implementations build for the host, so the corresponding module is not available when cross-compiling.
+// Cross-compiled tests may still make use of the macro itself in end-to-end tests.
+#if canImport(IdentityMacros)
+@testable import IdentityMacros
+
+let testAttachedIdentifiableMacro: [String: Macro.Type] = [
+    "Identifiable": AttachedIdentifiableMacro.self
+]
+#endif
+
+final class AttachedIdentifiableMacroTests: XCTestCase {
+    func testAttachedMacroSimpleUseExpansion() throws {
+        #if canImport(IdentityMacros)
+        assertMacroExpansion(
+            """
+            @Identifiable<UUID>
+            public struct TestStruct {
+                private var value: Int
+            }
+            """,
+            expandedSource: """
+            public struct TestStruct {
+                private var value: Int
+
+                public struct ID: Identifier {
+                    init(rawValue: UUID) {
+                        self.rawValue = rawValue
+                    }
+
+                    var rawValue: UUID
+                }
+
+                public var id: ID
+            }
+
+            extension TestStruct: Identifiable {
+            }
+            """,
+            macros: testAttachedIdentifiableMacro
+        )
+        #endif
+    }
+
+    func testAttachedMacroWithExtraAdoptions() throws {
+        #if canImport(IdentityMacros)
+        assertMacroExpansion(
+            """
+            @Identifiable<UUID>
+            public struct TestStruct: Resource, Media {
+                private var value: Int
+            }
+            """,
+            expandedSource: """
+            public struct TestStruct: Resource, Media {
+                private var value: Int
+
+                public struct ID: Identifier {
+                    init(rawValue: UUID) {
+                        self.rawValue = rawValue
+                    }
+
+                    var rawValue: UUID
+                }
+
+                public var id: ID
+            }
+
+            extension TestStruct: Identifiable {
+            }
+            """,
+            macros: testAttachedIdentifiableMacro
+        )
+        #endif
+    }
+}
+
+// Type declared here to verify that attached macro actually works, including embedded in another type.
+//
+// Compiler must be making an exception for extensions expanded from a macro as they are normally only allowed on global
+// scope.
+enum Namespace {
+    @Identifiable<UUID>
+    struct TestStruct {
+        var value: Int
+    }
+}

--- a/Tests/IdentityTests/AttachedIdentifierMacroTests.swift
+++ b/Tests/IdentityTests/AttachedIdentifierMacroTests.swift
@@ -1,5 +1,5 @@
 //
-//  IdentityMacrosTests.swift
+//  AttachedIdentifierMacroTests.swift
 //
 //
 //  Created by Óscar Morales Vivó on 9/21/23.
@@ -10,65 +10,20 @@ import Identity
 import SwiftDiagnostics
 import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport
-import Testing
+import XCTest
 
 // Macro implementations build for the host, so the corresponding module is not available when cross-compiling.
 // Cross-compiled tests may still make use of the macro itself in end-to-end tests.
 #if canImport(IdentityMacros)
 @testable import IdentityMacros
 
-let testFreestandingMacros: [String: Macro.Type] = [
-    "Identifier": FreestandingIdentifierMacro.self
-]
-
-let testAttachedMacros: [String: Macro.Type] = [
+let testAttachedIdentifierMacro: [String: Macro.Type] = [
     "Identifier": AttachedIdentifierMacro.self
 ]
 #endif
 
-protocol SomeProtocol {}
-
-protocol SomeOtherProtocol {}
-
-struct IdentifierMacroTests {
-    // Not quite a unit test but a check that the macro actually expands.
-    @Test func buildSimpleFreestandingMacro() throws {
-        struct TestStruct: Identifiable {
-            // Declaration has to happen in a different scope than creation. Within a local `struct` works.
-            #Identifier<UUID>("TestID")
-
-            var id: TestID
-        }
-
-        // If this builds we're good.
-        _ = TestStruct.TestID.unique()
-    }
-
-    private static var canRunMacroTests: Bool {
-        #if canImport(IdentityMacros)
-        return true
-        #else
-        return false
-        #endif
-    }
-
-    @Test(.enabled(if: canRunMacroTests)) func freestandingMacroExpansion() throws {
-        #if canImport(IdentityMacros)
-        assertMacroExpansion(
-            """
-            #Identifier<UUID>(\"ID\")
-            """,
-            expandedSource: """
-            struct ID: Identifier {
-                var rawValue: UUID
-            }
-            """,
-            macros: testFreestandingMacros
-        )
-        #endif
-    }
-
-    @Test(.enabled(if: canRunMacroTests)) func attachedMacroSimpleUseExpansion() throws {
+final class AttachedIdentifierMacroTests: XCTestCase {
+    func testAttachedMacroSimpleUseExpansion() throws {
         #if canImport(IdentityMacros)
         assertMacroExpansion(
             """
@@ -90,12 +45,12 @@ struct IdentifierMacroTests {
             extension ImageID: Identifier {
             }
             """,
-            macros: testAttachedMacros
+            macros: testAttachedIdentifierMacro
         )
         #endif
     }
 
-    @Test(.enabled(if: canRunMacroTests)) func attachedMacroWithExtraAdoptions() throws {
+    func testAttachedMacroWithExtraAdoptions() throws {
         #if canImport(IdentityMacros)
         assertMacroExpansion(
             """
@@ -116,11 +71,15 @@ struct IdentifierMacroTests {
             extension ImageID: Identifier {
             }
             """,
-            macros: testAttachedMacros
+            macros: testAttachedIdentifierMacro
         )
         #endif
     }
 }
+
+protocol SomeProtocol {}
+
+protocol SomeOtherProtocol {}
 
 // Type declared here to verify that attached macro actually works.
 //

--- a/Tests/IdentityTests/FreestandingIdentifierMacroTests.swift
+++ b/Tests/IdentityTests/FreestandingIdentifierMacroTests.swift
@@ -1,0 +1,54 @@
+//
+//  FreestandingIdentifierMacroTests.swift
+//
+//
+//  Created by Óscar Morales Vivó on 9/21/23.
+//
+
+import Foundation
+import Identity
+import SwiftDiagnostics
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import XCTest
+
+// Macro implementations build for the host, so the corresponding module is not available when cross-compiling.
+// Cross-compiled tests may still make use of the macro itself in end-to-end tests.
+#if canImport(IdentityMacros)
+@testable import IdentityMacros
+
+let testFreestandingMacros: [String: Macro.Type] = [
+    "Identifier": FreestandingIdentifierMacro.self
+]
+#endif
+
+final class FreestandingIdentifierMacroTests: XCTest {
+    // Not quite a unit test but a check that the macro actually expands.
+    func testBuildSimpleFreestandingMacro() throws {
+        struct TestStruct: Identifiable {
+            // Declaration has to happen in a different scope than creation. Within a local `struct` works.
+            #Identifier<UUID>("TestID")
+
+            var id: TestID
+        }
+
+        // If this builds we're good.
+        _ = TestStruct.TestID.unique()
+    }
+
+    func testFreestandingMacroExpansion() throws {
+        #if canImport(IdentityMacros)
+        assertMacroExpansion(
+            """
+            #Identifier<UUID>(\"ID\")
+            """,
+            expandedSource: """
+            struct ID: Identifier {
+                var rawValue: UUID
+            }
+            """,
+            macros: testFreestandingMacros
+        )
+        #endif
+    }
+}

--- a/Tests/IdentityTests/Identifier+CodableTests.swift
+++ b/Tests/IdentityTests/Identifier+CodableTests.swift
@@ -11,8 +11,8 @@ import XCTest
 
 // swiftlint:disable nesting
 struct Identifier_CodableTests {
-    // Tests that `String`-based Strongly typed IDs will encode/decode as just a plain string. Very useful for backend
-    // ID decoding...
+    // Tests that `String`-based identifier will encode/decode as just a plain string. Very useful for backend ID
+    // decoding...
     @Test func stringIDEncodesDecodesAsString() throws {
         struct DataStruct: Identifiable, Codable {
             struct ID: Identifier {
@@ -49,7 +49,7 @@ struct Identifier_CodableTests {
         #expect(dataStruct.dataInteger == decodedData.dataInteger)
     }
 
-    // Tests that `URL`-based Strongly typed IDs will encode/decode as just a plain string. Very useful for backend ID
+    // Tests that `URL`-based identifier will encode/decode as just a plain string. Very useful for backend ID
     // decoding...
     @Test func urlIDCodableEncodesAndDecodesAsPlainString() throws {
         struct DataStruct: Identifiable, Codable {
@@ -91,7 +91,7 @@ struct Identifier_CodableTests {
         #expect(dataStruct.dataInteger == decodedData.dataInteger)
     }
 
-    // Tests that `UUID`-based Strongly typed IDs will encode/decode as just a plain string. Very useful for backend ID
+    // Tests that `UUID`-based identifeir will encode/decode as just a plain string. Very useful for backend ID
     // decoding...
     @Test func uuidCodableEncodesDecodesAsLowercaseString() throws {
         struct DataStruct: Identifiable, Codable {
@@ -135,7 +135,7 @@ struct Identifier_CodableTests {
         #expect(dataStruct.dataInteger == decodedData.dataInteger)
     }
 
-    // Tests that `Int`-based Strongly typed IDs will encode/decode as just a plain integer. Very useful for backend ID
+    // Tests that `Int`-based identifier will encode/decode as just a plain integer. Very useful for backend ID
     // decoding...
     @Test func integerIDCodableEncodesDecodesAsInteger() throws {
         struct DataStruct: Identifiable, Codable {
@@ -178,7 +178,7 @@ struct Identifier_CodableTests {
         #expect(dataStruct.dataInteger == decodedData.dataInteger)
     }
 
-    // Tests that `Float`-based Strongly typed IDs will encode/decode as just a plain floating point value. Very useful
+    // Tests that `Float`-based identifier will encode/decode as just a plain floating point value. Very useful
     // for backend ID decoding...
     @Test func floatIDCodableEncodesDecodesAsFloat() throws {
         struct DataStruct: Identifiable, Codable {

--- a/Tests/IdentityTests/IdentityTests+IdentityMacros.swift
+++ b/Tests/IdentityTests/IdentityTests+IdentityMacros.swift
@@ -1,0 +1,14 @@
+//
+//  IdentityTests+IdentityMacros.swift
+//  swift-identity
+//
+//  Created by Óscar Morales Vivó on 6/21/25.
+//
+
+var canRunMacroTests: Bool {
+    #if canImport(IdentityMacros)
+    return true
+    #else
+    return false
+    #endif
+}


### PR DESCRIPTION
* Removed remnants of Strongly
* Added `@Identifiable` attached macro
* Implemented `@Identifiable` attached macro
* Moved macro tests back to XCTest since the assertions seem to require it or they just silently pass no matter what.