### PR TITLE
Avoid macro name clashes, clean up for Swift 6, deal with `CodingKeyRepresentable`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,12 +7,12 @@ import PackageDescription
 let package = Package(
     name: "swift-identity",
     platforms: [
-        .macOS(.v10_15),
-        .iOS(.v13),
-        .tvOS(.v13),
-        .watchOS(.v6),
+        .macOS("12.3"),
+        .iOS("15.4"),
+        .tvOS("15.4"),
+        .watchOS("8.5"),
         .visionOS(.v1),
-        .macCatalyst(.v13)
+        .macCatalyst("15.4")
     ],
     products: [
         .library(

--- a/Sources/Identity/Identifier/Identifier+CodingKeyRepresentable.swift
+++ b/Sources/Identity/Identifier/Identifier+CodingKeyRepresentable.swift
@@ -1,0 +1,30 @@
+//
+//  Identifier+CodingKeyRepresentable.swift
+//  swift-identity
+//
+//  Created by Óscar Morales Vivó on 11/9/25.
+//
+
+import Foundation
+
+public extension Identifier where RawValue: CodingKeyRepresentable, Self: CodingKeyRepresentable {
+    /// Default conformance of `CodingKeyRepresentable` when the backing type conforms.
+    ///
+    /// This will work for `String` and `Int`, as well as any other backing types that conform to the protocol.
+    ///
+    /// The initializer just redirects to the raw value initializer.
+    init?(codingKey: some CodingKey) {
+        guard let rawValue = RawValue(codingKey: codingKey) else {
+            return nil
+        }
+
+        self.init(rawValue: rawValue)
+    }
+
+    /// Default conformance of `CodingKeyRepresentable` when the backing type conforms.
+    ///
+    /// This will work for `String` and `Int`, as well as any other backing types that conform to the protocol.
+    var codingKey: any CodingKey {
+        rawValue.codingKey
+    }
+}

--- a/Sources/Identity/Identifier/Identifier+Macros.swift
+++ b/Sources/Identity/Identifier/Identifier+Macros.swift
@@ -14,9 +14,9 @@ import Foundation
 ///  - Backing: The type that backs the ``Identifier`` type, its `RawValue`.
 ///  - name: The name of the new ``Identifier`` type. Must be a valid type identifier at compile time.
 @freestanding(declaration, names: arbitrary)
-public macro Identifier<Backing: Hashable & Codable & Sendable>(_ name: StaticString) = #externalMacro(
+public macro ID<Backing: Hashable & Codable & Sendable>(_ name: StaticString) = #externalMacro(
     module: "IdentityMacros",
-    type: "FreestandingIdentifierMacro"
+    type: "FreestandingIDMacro"
 )
 
 /// A macro that adds conformance to `Identifier` to its attachee.
@@ -32,6 +32,29 @@ public macro Identifier<Backing: Hashable & Codable & Sendable>(_ name: StaticSt
 public macro Identifier<Backing: Hashable & Codable & Sendable>() = #externalMacro(
     module: "IdentityMacros",
     type: "AttachedIdentifierMacro"
+)
+
+/// A macro that adds conformance to `Identifier` to its attachee while allowing its use as a key for encodable
+/// dictionaries.
+///
+/// This macro acts like ``@Identifier`` but adds conformance to `CodingKeyRepresentable`. You should usually use this
+/// macro for identifiers with `Int` and `String` backing.
+///
+/// For historical reasons a `Dictionary` keyed by anything other than `String` or `Int` will not encode into a JSON
+/// dictionary but rather an array of alternating keys and values. Since fixing this behavior for `RawRepresentable`
+/// types would have been a breaking change, the `CodingKeyRepresentable` protocol was added so types conforming to it
+/// will encode/decode properly as JSON dictionary keys.
+///
+/// If you are backing your identifier with your own type and can make it conform to `CodingKeyRepresentable` you can
+/// use this macro to build identifiers backed by the type. For framework types it is best to add conformance to the
+/// wrappign identifier manually. A default implementation is offered for `UUID` so it can be taken advantage of by
+/// just declaring conformance on your identifier type.
+/// - Parameter Backing: The type that backs the ``Identifier`` type, its `RawValue`.
+@attached(member, names: named(RawValue), named(rawValue), named(init(rawValue:)))
+@attached(extension, conformances: Identifier, CodingKeyRepresentable)
+public macro KeyIdentifier<Backing: Hashable & Codable & Sendable & CodingKeyRepresentable>() = #externalMacro(
+    module: "IdentityMacros",
+    type: "AttachedKeyIdentifierMacro"
 )
 
 /// A macro that adds conformance to `Identifiable` with a new `Identifier` type to its attachee.

--- a/Sources/Identity/Identifier/Identifier+UUID.swift
+++ b/Sources/Identity/Identifier/Identifier+UUID.swift
@@ -39,3 +39,20 @@ public extension Identifier where RawValue == UUID, Self: CustomStringConvertibl
         rawValue.uuidString.lowercased()
     }
 }
+
+public extension Identifier where RawValue == UUID, Self: CodingKeyRepresentable {
+    /// Default conformance of UUID-backed ``Identifier`` types to `CodingKeyRepresentable`
+    ///
+    /// We translate to/from the lowercase `UUID.uuidString` as per the policy of the other default conformances.
+    init?(codingKey: some CodingKey) {
+        guard let uuid = UUID(uuidString: codingKey.stringValue) else {
+            return nil
+        }
+
+        self.init(rawValue: uuid)
+    }
+
+    var codingKey: any CodingKey {
+        rawValue.uuidString.lowercased().codingKey
+    }
+}

--- a/Sources/IdentityMacros/AttachedKeyIdentifierMacro.swift
+++ b/Sources/IdentityMacros/AttachedKeyIdentifierMacro.swift
@@ -1,0 +1,59 @@
+//
+//  AttachedKeyIdentifierMacro.swift
+//  swift-identity
+//
+//  Created by Óscar Morales Vivó on 6/8/25.
+//
+
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+public struct AttachedKeyIdentifierMacro {}
+
+// MARK: - MemberMacro Conformance
+
+extension AttachedKeyIdentifierMacro: MemberMacro {
+    public static func expansion(
+        of _: AttributeSyntax,
+        providingMembersOf declaration: some DeclGroupSyntax,
+        conformingTo _: [TypeSyntax],
+        in _: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        guard let attributeListElement = declaration.attributes.first,
+              case let .attribute(attribute) = attributeListElement,
+              let genericClause = attribute.attributeName.as(IdentifierTypeSyntax.self)?.genericArgumentClause,
+              let genericParam = genericClause.arguments.first
+        else {
+            // This should only happen due to toolset error or out of sync macro declaration so let's blow up.
+            preconditionFailure("Unable to find macro declaration, somehow.")
+        }
+
+        // If the type is `public` we want the generated declarations to also be `public`.
+        let access = declaration.modifiers.first(where: \.isNeededAccessLevelModifier)
+
+        return [
+            "\(access)init(rawValue: \(genericParam)) { self.rawValue = rawValue }",
+            "\(access)typealias RawValue = \(genericParam)",
+            "\(access)var rawValue: \(genericParam)"
+        ]
+    }
+}
+
+// MARK: - ExtensionMacro Conformance
+
+extension AttachedKeyIdentifierMacro: ExtensionMacro {
+    public static func expansion(
+        of _: AttributeSyntax,
+        attachedTo _: some DeclGroupSyntax,
+        providingExtensionsOf type: some TypeSyntaxProtocol,
+        conformingTo _: [TypeSyntax],
+        in _: some MacroExpansionContext
+    ) throws -> [ExtensionDeclSyntax] {
+        // This is all simple enough.
+        let identifierConformance = try ExtensionDeclSyntax(
+            "extension \(type.trimmed): Identifier, CodingKeyRepresentable {}"
+        )
+
+        return [identifierConformance]
+    }
+}

--- a/Sources/IdentityMacros/FreestandingIDMacro.swift
+++ b/Sources/IdentityMacros/FreestandingIDMacro.swift
@@ -1,5 +1,5 @@
 //
-//  FreestandingIdentifierMacro.swift
+//  FreestandingIDMacro.swift
 //  swift-identity
 //
 //  Created by Óscar Morales Vivó on 9/20/23.
@@ -8,11 +8,11 @@
 import SwiftSyntax
 import SwiftSyntaxMacros
 
-public struct FreestandingIdentifierMacro {}
+public struct FreestandingIDMacro {}
 
 // MARK: - DeclarationMacro Conformance
 
-extension FreestandingIdentifierMacro: DeclarationMacro {
+extension FreestandingIDMacro: DeclarationMacro {
     public static func expansion(
         of node: some FreestandingMacroExpansionSyntax,
         in _: some MacroExpansionContext

--- a/Sources/IdentityMacros/IdentityMacrosTestPlugin.swift
+++ b/Sources/IdentityMacros/IdentityMacrosTestPlugin.swift
@@ -14,7 +14,8 @@ struct IdentityMacrosTestPlugin: CompilerPlugin {
     let providingMacros: [Macro.Type] = [
         AttachedIdentifiableMacro.self,
         AttachedIdentifierMacro.self,
-        FreestandingIdentifierMacro.self
+        AttachedKeyIdentifierMacro.self,
+        FreestandingIDMacro.self
     ]
 }
 

--- a/Tests/IdentityTests/Identifier/Identifier+UUIDTests.swift
+++ b/Tests/IdentityTests/Identifier/Identifier+UUIDTests.swift
@@ -10,7 +10,7 @@ import Identity
 import Testing
 
 struct IdentifierUUIDTests {
-    #Identifier<UUID>("TestID")
+    #ID<UUID>("TestID")
 
     @Test("Checks that it converts to lowercase string")
     func convertToLowercaseString() {
@@ -31,5 +31,24 @@ struct IdentifierUUIDTests {
         let jsonString = String(data: data, encoding: .utf8)
 
         #expect(jsonString == "[\"\(uuid.uuidString.lowercased())\"]")
+    }
+
+    @Identifier<UUID> struct TestKeyID: CodingKeyRepresentable {}
+
+    @Test("Checks that CodingKeyRepresentable conformance works as intended")
+    func codingKeyRepresentableConformance() throws {
+        let uuid1 = try #require(UUID(uuidString: "ec71322a-2d12-4d35-83fe-99f70faa7e92"))
+        let uuid2 = try #require(UUID(uuidString: "c2cc54c6-86ac-4e1f-95d7-333eb7a7b1ad"))
+
+        let uuidKeyed = [TestKeyID(rawValue: uuid1): "Keyed by UUID 1", TestKeyID(rawValue: uuid2): "Keyed by UUID 2"]
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(uuidKeyed)
+
+        let decoder = JSONDecoder()
+        let decoded = try decoder.decode([String: String].self, from: data)
+
+        #expect(decoded[uuid1.uuidString.lowercased()] == "Keyed by UUID 1")
+        #expect(decoded[uuid2.uuidString.lowercased()] == "Keyed by UUID 2")
     }
 }

--- a/Tests/IdentityTests/Identifier/IdentifierTests.swift
+++ b/Tests/IdentityTests/Identifier/IdentifierTests.swift
@@ -30,7 +30,7 @@ struct IdentifierTests {
     // Testing using a non-trivial value type as an ID type.
     @Test func complexIdentifierWorks() {
         struct Person {
-            #Identifier<PersonName>("ID")
+            #ID<PersonName>("ID")
 
             var id: ID {
                 .init(rawValue: .init(firstName: firstName, lastName: lastName))

--- a/Tests/IdentityTests/IdentityMacros/AttachedIdentifiableMacroTests.swift
+++ b/Tests/IdentityTests/IdentityMacros/AttachedIdentifiableMacroTests.swift
@@ -17,11 +17,13 @@ import XCTest
 #if canImport(IdentityMacros)
 @testable import IdentityMacros
 
+@MainActor
 let testAttachedIdentifiableMacro: [String: Macro.Type] = [
     "Identifiable": AttachedIdentifiableMacro.self
 ]
 #endif
 
+@MainActor
 final class AttachedIdentifiableMacroTests: XCTestCase {
     func testAttachedMacroSimpleUseExpansion() throws {
         #if canImport(IdentityMacros)

--- a/Tests/IdentityTests/IdentityMacros/AttachedKeyIdentifierMacroTests.swift
+++ b/Tests/IdentityTests/IdentityMacros/AttachedKeyIdentifierMacroTests.swift
@@ -1,8 +1,8 @@
 //
-//  AttachedIdentifierMacroTests.swift
+//  AttachedKeyIdentifierMacroTests.swift
 //  swift-identity
 //
-//  Created by Óscar Morales Vivó on 9/21/23.
+//  Created by Óscar Morales Vivó on 11/9/25.
 //
 
 import Foundation
@@ -18,36 +18,36 @@ import XCTest
 @testable import IdentityMacros
 
 @MainActor
-let testAttachedIdentifierMacro: [String: Macro.Type] = [
-    "Identifier": AttachedIdentifierMacro.self
+let testAttachedKeyIdentifierMacro: [String: Macro.Type] = [
+    "KeyIdentifier": AttachedKeyIdentifierMacro.self
 ]
 #endif
 
 @MainActor
-final class AttachedIdentifierMacroTests: XCTestCase {
+final class AttachedKeyIdentifierMacroTests: XCTestCase {
     func testAttachedMacroSimpleUseExpansion() throws {
         #if canImport(IdentityMacros)
         assertMacroExpansion(
             """
-            @Identifier<UUID>
-            public struct ImageID: ResourceID, FileID, MediaID {}
+            @KeyIdentifier<String>
+            public struct ImageID {}
             """,
             expandedSource: """
-            public struct ImageID: ResourceID, FileID, MediaID {
+            public struct ImageID {
 
-                public init(rawValue: UUID) {
+                public init(rawValue: String) {
                     self.rawValue = rawValue
                 }
 
-                public typealias RawValue = UUID
+                public typealias RawValue = String
 
-                public var rawValue: UUID
+                public var rawValue: String
             }
 
-            extension ImageID: Identifier {
+            extension ImageID: Identifier, CodingKeyRepresentable {
             }
             """,
-            macros: testAttachedIdentifierMacro
+            macros: testAttachedKeyIdentifierMacro
         )
         #endif
     }
@@ -56,40 +56,32 @@ final class AttachedIdentifierMacroTests: XCTestCase {
         #if canImport(IdentityMacros)
         assertMacroExpansion(
             """
-            @Identifier<UUID> struct ImageID: ResourceID, FileID, MediaID {}
+            @KeyIdentifier<String> struct ImageID: ResourceID, FileID, MediaID {}
             """,
             expandedSource: """
             struct ImageID: ResourceID, FileID, MediaID {
 
-                init(rawValue: UUID) {
+                init(rawValue: String) {
                     self.rawValue = rawValue
                 }
 
-                typealias RawValue = UUID
+                typealias RawValue = String
 
-                var rawValue: UUID
+                var rawValue: String
             }
 
-            extension ImageID: Identifier {
+            extension ImageID: Identifier, CodingKeyRepresentable {
             }
             """,
-            macros: testAttachedIdentifierMacro
+            macros: testAttachedKeyIdentifierMacro
         )
         #endif
     }
 }
 
-protocol SomeProtocol {}
-
-protocol SomeOtherProtocol {}
-
-@Identifier<UUID> struct GlobalScopeID {}
-
 // Type declared here to verify that attached macro actually works.
 //
 // Cannot be used in a local type.
-struct TestStruct: Identifiable {
-    @Identifier<UUID> struct TestID: SomeProtocol, SomeOtherProtocol {}
-
-    var id: TestID
+extension TestStruct {
+    @KeyIdentifier<String> struct TestKeyID: SomeProtocol, SomeOtherProtocol {}
 }

--- a/Tests/IdentityTests/IdentityMacros/FreestandingIDMacroTests.swift
+++ b/Tests/IdentityTests/IdentityMacros/FreestandingIDMacroTests.swift
@@ -1,5 +1,5 @@
 //
-//  FreestandingIdentifierMacroTests.swift
+//  FreestandingIDMacroTests.swift
 //  swift-identity
 //
 //  Created by Óscar Morales Vivó on 9/21/23.
@@ -17,17 +17,19 @@ import XCTest
 #if canImport(IdentityMacros)
 @testable import IdentityMacros
 
+@MainActor
 let testFreestandingMacros: [String: Macro.Type] = [
-    "Identifier": FreestandingIdentifierMacro.self
+    "Identifier": FreestandingIDMacro.self
 ]
 #endif
 
-final class FreestandingIdentifierMacroTests: XCTest {
+@MainActor
+final class FreestandingIDMacroTests: XCTest {
     // Not quite a unit test but a check that the macro actually expands.
     func testBuildSimpleFreestandingMacro() throws {
         struct TestStruct: Identifiable {
             // Declaration has to happen in a different scope than creation. Within a local `struct` works.
-            #Identifier<UUID>("TestID")
+            #ID<UUID>("TestID")
 
             var id: TestID
         }
@@ -40,7 +42,7 @@ final class FreestandingIdentifierMacroTests: XCTest {
         #if canImport(IdentityMacros)
         assertMacroExpansion(
             """
-            #Identifier<UUID>(\"ID\")
+            #ID<UUID>(\"ID\")
             """,
             expandedSource: """
             struct ID: Identifier {


### PR DESCRIPTION
Some changes were needed due to either tooling updates or seen as required for regular use in nontrivial projects.

* The compiler does a terrible job when a freestanding macro and an attached macro have the same name and mixes them up even if it's obvious which one should be used.
  * To resolve that `#Identifier` has been renamed to `#ID`. Unfortunately this is a breaking change so we'll need to deploy a new major version.
* Ensuring some issues with Swift 6.2 compiler betas don't manifest.
* Since a very common usage pattern for identifiers is to use them as keys for dictionaries that are then JSON-encoded for backend consumption, we need to make sure we can easily create identifiers that conform to `CodingKeyRepresentable`.
  * Once again the compiler can't deal with macro overload so a new macro needs a new name: welcome `@KeyIdentifier`
  * Added default conformance methods for `Identifier<UUID>` since it's going to commonly show up.

In addition added tests for all the new functionality.